### PR TITLE
ch32v103

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ isp55e0 has been tested on:
   - a CH582 with a bootloader version 2.4.0
   - a CH32F103C8T6 with a bootloader version 2.3.1
   - a CH32F103C8T6 with a bootloader version 2.5.0
+  - a CH32V103C8T6 with a bootloader version 2.6.0
 
 
 Build

--- a/isp55e0.c
+++ b/isp55e0.c
@@ -101,6 +101,15 @@ static const struct ch_profile profiles[] = {
 		.need_last_write = true,
 	},
 	{
+		.name = "CH32V103",
+		.family = 0x15,
+		.type = 0x3f,
+		.code_flash_size = 65536,
+		.mcu_id_len = 8,
+		.need_remove_wp = true,
+		.need_last_write = true,
+	},
+	{
 		.name = "CH582",
 		.family = 0x16,
 		.type = 0x82,
@@ -697,6 +706,7 @@ int main(int argc, char *argv[])
 		break;
 
 	case 0x020500:
+	case 0x020600:
 	case 0x020800:
 		dev.wait_reboot_resp = true;
 		break;


### PR DESCRIPTION
This is a patch to use isp55e0 with the ch32v103 - the risc-v version of the ch32f103 arm.
Thanks for this small tool.

[aliexpress](https://www.aliexpress.com/item/1005001474741936.html)
[git](https://github.com/WeActStudio/WeActStudio.BluePill-Plus-CH32)