### PR TITLE
Add new bootloader version

### DIFF
--- a/isp55e0.c
+++ b/isp55e0.c
@@ -716,6 +716,7 @@ int main(int argc, char *argv[])
 	case 0x020500:
 	case 0x020600:
 	case 0x020800:
+	case 0x020900:
 		dev.wait_reboot_resp = true;
 		break;
 


### PR DESCRIPTION
I got a newer bootloader version on my current CH579M device, and it flashes the device fine.

```
Found device CH579
Bootloader version 2.9.0
Unique chip ID f6-08-26-26-3b-38-57-67
Firmware is good
```