### PR TITLE
Adding CH32V203C8T6 with bootloader version 2.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ isp55e0 has been tested on:
   - a CH32F103C8T6 with a bootloader version 2.3.1
   - a CH32F103C8T6 with a bootloader version 2.5.0
   - a CH32V103C8T6 with a bootloader version 2.6.0
+  - a CH32V203C8T6 with a bootloader version 2.7.0
   - a CH32V203G8R6 with a bootloader version 2.6.0
   - a CH32V307VCT6 with a bootloader version 2.9.0
 

--- a/isp55e0.c
+++ b/isp55e0.c
@@ -1211,6 +1211,7 @@ int main(int argc, char *argv[])
 
 	case 0x020500:
 	case 0x020600:
+	case 0x020700:
 	case 0x020800:
 	case 0x020900:
 		dev.wait_reboot_resp = true;


### PR DESCRIPTION
I just tested it, and it works nicely.

```
Found device CH32V203C8T6
Bootloader version 2.7.0
Unique chip ID ...
Code flashing successful
Firmware is good
```